### PR TITLE
[FIX] - Use RegEx to parse exclusion class for flexibility

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -463,8 +463,18 @@ function generateToc( $headings, $attributes )
       $next_depth = '';
     }
 
+	// Get class attributes and check for `simpletoc-hidden` to exclude the headline.
+	preg_match( '/class="([^"]+)"/', $headline, $matches );
+	$exclude_headline = false;
+	if ( isset( $matches[1] ) ) {
+		$headline_classes = explode( ' ', $matches[1] );
+		if ( in_array( 'simpletoc-hidden', $headline_classes, true ) ) {
+			$exclude_headline = true;
+		}
+	}
+
     // skip this heading because a max depth is set.
-    if ($this_depth > $attributes['max_level'] or strpos($headline, 'class="simpletoc-hidden') > 0) {
+    if ($this_depth > $attributes['max_level'] or $exclude_headline) {
       goto closelist;
     }
 


### PR DESCRIPTION
Fixes #28 

This PR solves an issue when the `simpletoc-hidden` is not the first item in the `class` attribute list.

The current behavior searches for the `simpletoc-hidden` class at the beginning of a class attribute:

`strpos($headline, 'class="simpletoc-hidden')`

The proposed behavior is to use a RegEx to parse the class attribute and check to see if the `simpletoc-hidden` is part of a list of classes.

This has been tested locally with GenerateBlocks and other headings.