### PR TITLE
Add Load State to TOC Accordion for Delayed or Deferred JS

### DIFF
--- a/assets/accordion.js
+++ b/assets/accordion.js
@@ -1,7 +1,7 @@
 /**
  * SimpleTOC load function.
  */
-const simpletocLoad = function() {
+const simpletocLoad = function () {
 	const buttons = document.querySelectorAll( 'button.simpletoc-collapsible' );
 
 	buttons.forEach( ( button ) => {
@@ -20,7 +20,7 @@ const simpletocLoad = function() {
 				: '0px';
 		} );
 	} );
-}
+};
 
 // Allow others to call function if needed.
 window.simpletocLoad = simpletocLoad;

--- a/assets/accordion.js
+++ b/assets/accordion.js
@@ -1,4 +1,7 @@
-document.addEventListener( 'DOMContentLoaded', () => {
+/**
+ * SimpleTOC load function.
+ */
+const simpletocLoad = function() {
 	const buttons = document.querySelectorAll( 'button.simpletoc-collapsible' );
 
 	buttons.forEach( ( button ) => {
@@ -17,4 +20,17 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				: '0px';
 		} );
 	} );
-} );
+}
+
+// Allow others to call function if needed.
+window.simpletocLoad = simpletocLoad;
+
+// Check to see if the document is already loaded.
+if ( document.readyState === 'complete' || document.readyState !== 'loading' ) {
+	simpletocLoad();
+} else {
+	// Fallback event if the document is not loaded.
+	document.addEventListener( 'DOMContentLoaded', () => {
+		simpletocLoad();
+	} );
+}


### PR DESCRIPTION
Fixes #62 

This PR introduces a check that checks if the DOM has already been loaded. If it has, it loads the TOC accordion as normal.

If the document hasn't already been loaded, then the `DOMContentLoaded` event is used to load the TOC.