### PR TITLE
Fix GenerateBlocks IDs for 2.0.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -154,8 +154,21 @@ add_filter('the_content', 'simpletoc_add_ids_to_content', 1);
 function add_ids_to_blocks_recursive($blocks)
 {
 
+	$supported_blocks = array(
+		'core/heading',
+		'generateblocks/text',
+		'generateblocks/headline',
+	);
+
+	/**
+	 * Filter to add supported blocks for IDs.
+	 *
+	 * @param array $supported_blocks The array of supported blocks.
+	 */
+	$supported_blocks = apply_filters( 'simpletoc_supported_blocks_for_ids', $supported_blocks );
+
     foreach ($blocks as &$block) {
-        if (isset($block['blockName']) && ($block['blockName'] === 'core/heading' || $block['blockName'] === 'generateblocks/headline') && isset($block['innerHTML']) && isset($block['innerContent']) && isset($block['innerContent'][0])) {
+        if (isset($block['blockName']) && in_array( $block['blockName'], $supported_blocks ) && isset($block['innerHTML']) && isset($block['innerContent']) && isset($block['innerContent'][0])) {
             $block['innerHTML'] = add_anchor_attribute($block['innerHTML']);
             $block['innerContent'][0] = add_anchor_attribute($block['innerContent'][0]);
         } elseif (isset($block['attrs']['ref'])) {


### PR DESCRIPTION
Resolves #68 

1. Adds an array of approved blocks (include the GenerateBlocks text block)
2. Will render if array of blocks matches.
3. A filter is added for other blocks that may need to be added programmatically.