### PR TITLE
Update checkout action to v5

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: WordPress.org plugin asset/readme update
               uses: 10up/action-wordpress-plugin-asset-update@stable


### PR DESCRIPTION
## Summary
- update the assets workflow to use actions/checkout@v5

## Validation
- verified the workflow diff only changes actions/checkout@v4 to actions/checkout@v5